### PR TITLE
Updated proxy_redirect to remove trailing slashes.

### DIFF
--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -22,7 +22,7 @@ server {
 
 <% if @redirect -%>
   rewrite ^ <%= @url %>$request_uri? <%= @redirect %>;
-<% else -%>  
+<% else -%>
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
@@ -31,7 +31,7 @@ server {
     proxy_pass <%= @url %>;
     proxy_redirect default;
 <%   if @ssl_key_path -%>
-    proxy_redirect http://<%= @server_name %>/ https://<%= @server_name %>/;
+    proxy_redirect http://<%= @server_name %> https://<%= @server_name %>;
 <%   end -%>
   }
 <% end -%>


### PR DESCRIPTION
Is there a good reason why the proxy has trailing slashes? Using trailing slashes like this can cause issues when testing applications that reverse proxy using port numbers. This can make it difficult to use Test Kitchen, for instance, to converge a machine that relies on http://localhost:8080 reverse proxying to https://localhost:443. (since the response headers will get signed with something like "https://localhost/:443" instead).

An even better fix for this might be to allow users to change the proxy redirects themselves through an attribute.